### PR TITLE
Add discard gem for logical deletion of expenses

### DIFF
--- a/app/controllers/analyses_controller.rb
+++ b/app/controllers/analyses_controller.rb
@@ -6,7 +6,7 @@ class AnalysesController < ApplicationController
       params[:tab] = 'expenses'
     end
     @categories = Category.available_categories_with_budgets(@current_user)
-    @expenses = Expense.all_for_one_month(@current_user, period_params)
+    @expenses = Expense.kept.all_for_one_month(@current_user, period_params)
     @incomes = @current_user.incomes.where(income_params)
     @balance = @current_user.balances.find_by(period: period_params)
   end

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -52,7 +52,7 @@ class ExpensesController < ApplicationController
 
   def destroy
     @expense = Expense.find(params[:id])
-    @expense.destroy
+    @expense.discard
     create_notification(@expense)
     redirect_to expenses_path(period: @expense.date.to_s_as_period), notice: "出費を削除しました"
   end

--- a/app/controllers/repeat_expenses_controller.rb
+++ b/app/controllers/repeat_expenses_controller.rb
@@ -88,15 +88,15 @@ class RepeatExpensesController < ApplicationController
     ActiveRecord::Base.transaction do
       begin
         if params[:updated_period] == "updated_all"
-          target_expenses.each(&:destroy)
-          target_repeat_expenses.each(&:destroy)
+          target_expenses.each(&:discard)
+          target_repeat_expenses.each(&:discard)
         elsif params[:updated_period] == "updated_only_future"
           target_expenses.each do |expense|
             if expense.date >= Date.current
-              expense.destroy
+              expense.discard
             end
           end
-          target_repeat_expenses.each(&:destroy)
+          target_repeat_expenses.each(&:discard)
         end
       rescue
         flash[:error] = ["繰り返し出費の削除に失敗しました。"]

--- a/app/decorators/expense_decorator.rb
+++ b/app/decorators/expense_decorator.rb
@@ -2,7 +2,7 @@ module ExpenseDecorator
   include CommonDecorator
   def show_date(expenses, current_user, index)
     if index == 0 || date != expenses[index - 1].date
-      expenses_of_the_date = expenses.select{ |e| e.date == date }
+      expenses_of_the_date = expenses.select{ |e| e.date == date && !e.discarded? }
       number_of_category = expenses_of_the_date.map(&:category_id).uniq.size
       if number_of_category == 1
         sum_of_the_date = category.expenses_sum(expenses_of_the_date, current_user)

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -34,6 +34,7 @@
 class Expense < ApplicationRecord
   include BalanceHelper
   include PercentCalculator
+  include Discard::Model
 
   enum percent: { manual_amount: -1, pay_all: 0, pay_half: 1, pay_one_third: 2, pay_two_thirds: 3, pay_nothing: 4 }
   enum payment_method: { cash: 0, credit_card: 1, account_transfer: 2 }
@@ -59,6 +60,7 @@ class Expense < ApplicationRecord
   scope :both_f, -> {where(is_for_both: false)}
   scope :both_t, -> {where(is_for_both: true)}
   scope :newer, -> {order(date: :desc, created_at: :desc)}
+  scope :kept, -> { undiscarded }
 
   after_initialize { self.is_new = true unless self.id }
   before_save :set_differences
@@ -75,7 +77,7 @@ class Expense < ApplicationRecord
   # @return [Expense]
   def self.all_for_one_month(user, period)
     partner = user.partner
-    self.includes(:user, :category).references(:users, :categories).where(users: {id: [user, partner]}).one_month(period).order(date: :desc, created_at: :desc)
+    self.kept.includes(:user, :category).references(:users, :categories).where(users: {id: [user, partner]}).one_month(period).order(date: :desc, created_at: :desc)
   end
 
   # @note 該当月と引数のカテゴリの出費でユーザーの全ての出費とパートナーの二人の出費を取得
@@ -85,7 +87,7 @@ class Expense < ApplicationRecord
   # @return [Expense]
   def self.specified_category_for_one_month(user, category, period)
     partner = user.partner
-    self.includes(:user, :category).references(:users, :categories).where(categories: {id: category}).one_month(period).where("users.id = ? OR (users.id = ? AND is_for_both = ?)", user.id, partner.id, true).order(date: :desc, created_at: :desc)
+    self.kept.includes(:user, :category).references(:users, :categories).where(categories: {id: category}).one_month(period).where("users.id = ? OR (users.id = ? AND is_for_both = ?)", user.id, partner.id, true).order(date: :desc, created_at: :desc)
   end
 
   # その月の支出合計額を算出
@@ -93,8 +95,8 @@ class Expense < ApplicationRecord
   # @param [String] period"2019-01"
   # @return Integer 支出合計額
   def self.one_month_total_expenditures(user, period)
-    user_expenses = user.expenses.one_month(period)
-    user_expenses.both_f.sum(:amount) + user_expenses.both_t.sum(:mypay) + user.partner.expenses.one_month(period).both_t.sum(:partnerpay)
+    user_expenses = user.expenses.kept.one_month(period)
+    user_expenses.both_f.sum(:amount) + user_expenses.both_t.sum(:mypay) + user.partner.expenses.kept.one_month(period).both_t.sum(:partnerpay)
   end
 
   # @param [User] user
@@ -102,7 +104,7 @@ class Expense < ApplicationRecord
   # @param [String] period"2019-01"
   # @return [Expense::ActiveRecord_AssociationRelation] expenses
   def self.both_expenses_until_one_month(user, partner, period=Date.current.to_s_as_period)
-    eager_load(:user).where(users: {id: [user, partner]}).both_t.where('date <= ?', period.to_end_of_month)
+    eager_load(:user).where(users: {id: [user, partner]}).kept.both_t.where('date <= ?', period.to_end_of_month)
   end
 
   # @param [User] user
@@ -147,7 +149,7 @@ class Expense < ApplicationRecord
   # @return [Integer]
   def self.own_payment_for_one_month(user, period)
     partner = user.partner
-    expenses = self.eager_load(:user).where(users: {id: [user, partner]}).one_month(period).both_t
+    expenses = self.eager_load(:user).where(users: {id: [user, partner]}).kept.one_month(period).both_t
     user_expenses, partner_expenses = filtered_expenses_by_user(user, partner, expenses)
     user_expenses.sum(&:mypay) + partner_expenses.sum(&:partnerpay) - user_expenses.sum(&:amount)
   end

--- a/spec/models/expense_spec.rb
+++ b/spec/models/expense_spec.rb
@@ -293,4 +293,39 @@ RSpec.describe Expense, type: :model do
     end
   end
 
+  describe "Discard functionality" do
+    before do
+      @user = create(:user)
+      @category = create(:category, user: @user)
+    end
+
+    it "discards an expense" do
+      expense = Expense.create(
+        user: @user,
+        category: @category,
+        amount: 1000,
+        date: Time.zone.today
+      )
+      expense.discard
+      expect(expense).to be_discarded
+    end
+
+    it "does not include discarded expenses in the default scope" do
+      expense1 = Expense.create(
+        user: @user,
+        category: @category,
+        amount: 1000,
+        date: Time.zone.today
+      )
+      expense2 = Expense.create(
+        user: @user,
+        category: @category,
+        amount: 2000,
+        date: Time.zone.today
+      )
+      expense1.discard
+      expect(Expense.kept).not_to include(expense1)
+      expect(Expense.kept).to include(expense2)
+    end
+  end
 end


### PR DESCRIPTION
Add functionality to logically delete expenses using the `discard` gem.

* **Expense Model**
  - Include `discard` in the `Expense` model.
  - Add a scope to exclude discarded records.
  - Update methods to exclude discarded expenses in calculations and queries.

* **Expenses Controller**
  - Update the `destroy` action to use `discard` instead of `destroy`.

* **Analyses Controller**
  - Update the `index` action to exclude discarded expenses.

* **Repeat Expenses Controller**
  - Update the `destroy` action to use `discard` instead of `destroy`.

* **Expense Decorator**
  - Update the `show_date` method to exclude discarded expenses.

* **Expense Spec**
  - Add tests for the `discard` functionality.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kawasaki-shohei/household_account_book/pull/369?shareId=16c0f591-d0a9-4075-adc0-b751c8f7622f).